### PR TITLE
Refactor: Remove EventLayer enum and ApplicationLevelEvent class

### DIFF
--- a/Runtime/BusEvent.cs
+++ b/Runtime/BusEvent.cs
@@ -3,19 +3,12 @@ using System.Collections.Generic;
 
 namespace Nopnag.EventBusLib // Updated namespace
 {
-  public enum EventLayer
-  {
-    Application,
-    Scene
-  }
 
   // Interface for parameter types, assuming it's needed by BusEvent
   public interface IParameter {}
 
   public class BusEvent
   {
-    public static EventLayer Layer = EventLayer.Scene;
-
     readonly Dictionary<Type, object> _dict;
     readonly Dictionary<Type, object> _genericDict;
 
@@ -64,10 +57,5 @@ namespace Nopnag.EventBusLib // Updated namespace
     {
       IsPropagationStopped = true;
     }
-  }
-
-  public class ApplicationLevelEvent : BusEvent
-  {
-    public new static EventLayer Layer = EventLayer.Application;
   }
 } 


### PR DESCRIPTION
This pull request removes the EventLayer enum, the ApplicationLevelEvent class, and the associated static Layer field from BusEvent.cs.
This change simplifies the event class structure by removing the distinction between Application and Scene level events that was previously managed by these constructs. The goal is to streamline the core BusEvent definition.