### PR TITLE
feat: Add RaiseUniqueId property to track individual event dispatches

### DIFF
--- a/Runtime/BusEvent.cs
+++ b/Runtime/BusEvent.cs
@@ -18,6 +18,14 @@ namespace Nopnag.EventBusLib // Updated namespace
       _genericDict = new Dictionary<Type, object>();
     }
 
+    // A new unique identifier assigned per raise operation.
+    // Readable publicly, but only settable within this assembly (library-internal).
+    public long RaiseUniqueId { get; internal set; }
+
+    // Internal raise depth tracking to ensure RaiseUniqueId is assigned only once
+    // for the outermost raise call, while nested/forwarded raises share the same ID.
+    internal int ActiveRaiseDepth { get; set; }
+
     public virtual bool IsPropagationStopped { get; set; }
 
     public object Get<T>() where T : IParameter

--- a/Runtime/EventBus.cs
+++ b/Runtime/EventBus.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace Nopnag.EventBusLib // Updated namespace
 {
@@ -29,6 +30,13 @@ namespace Nopnag.EventBusLib // Updated namespace
   // Static EventBus API (unchanged for backward compatibility)
   public static class EventBus
   {
+    static long _raiseIdCounter;
+
+    internal static long NextRaiseUniqueId()
+    {
+      return Interlocked.Increment(ref _raiseIdCounter);
+    }
+
     public static EventQuery<TEvent> Query<TEvent>() where TEvent : BusEvent
     {
       return EventBus<TEvent>.SelfQuery;
@@ -128,24 +136,19 @@ namespace Nopnag.EventBusLib // Updated namespace
 
     public virtual void Raise(T @event)
     {
+      var isDepthZero = @event.ActiveRaiseDepth == 0;
+      @event.ActiveRaiseDepth++;
+      if (isDepthZero)
+      {
+        @event.RaiseUniqueId = EventBus.NextRaiseUniqueId();
+      }
+
       _isRaising = true;
-
-      foreach (var listener in _hash)
+      try
       {
-        listener(@event);
-        if (@event.IsPropagationStopped)
+        foreach (var listener in _hash)
         {
-          _isRaising = false;
-          ProcessOperationQueue();
-          return;
-        }
-      }
-
-      foreach (var type in _dictionary.Keys)
-      {
-        if (_dictionary.TryGetValue(type, out var eventQuery))
-        {
-          eventQuery.Raise(@event);
+          listener(@event);
           if (@event.IsPropagationStopped)
           {
             _isRaising = false;
@@ -153,24 +156,42 @@ namespace Nopnag.EventBusLib // Updated namespace
             return;
           }
         }
-      }
 
-      foreach (var type in _genericDictionary.Keys)
-      {
-        if (_genericDictionary.TryGetValue(type, out var eventQuery))
+        foreach (var type in _dictionary.Keys)
         {
-          eventQuery.Raise(@event);
-          if (@event.IsPropagationStopped)
+          if (_dictionary.TryGetValue(type, out var eventQuery))
           {
-            _isRaising = false;
-            ProcessOperationQueue();
-            return;
+            eventQuery.Raise(@event);
+            if (@event.IsPropagationStopped)
+            {
+              _isRaising = false;
+              ProcessOperationQueue();
+              return;
+            }
           }
         }
-      }
 
-      _isRaising = false;
-      ProcessOperationQueue();
+        foreach (var type in _genericDictionary.Keys)
+        {
+          if (_genericDictionary.TryGetValue(type, out var eventQuery))
+          {
+            eventQuery.Raise(@event);
+            if (@event.IsPropagationStopped)
+            {
+              _isRaising = false;
+              ProcessOperationQueue();
+              return;
+            }
+          }
+        }
+
+        _isRaising = false;
+        ProcessOperationQueue();
+      }
+      finally
+      {
+        @event.ActiveRaiseDepth--;
+      }
     }
 
     public EventQuery<T> Where<TParameterType>(in object value) where TParameterType : IParameter
@@ -234,11 +255,25 @@ namespace Nopnag.EventBusLib // Updated namespace
 
     public override void Raise(T @event)
     {
-      var type = typeof(TParameterType);
-      var value = @event.Get<TParameterType>();
-      EventQuery<T> eventQuery;
-      if (value != null && _valueDictionary.TryGetValue(value, out eventQuery))
-        eventQuery.Raise(@event);
+      var isDepthZero = @event.ActiveRaiseDepth == 0;
+      @event.ActiveRaiseDepth++;
+      if (isDepthZero)
+      {
+        @event.RaiseUniqueId = EventBus.NextRaiseUniqueId();
+      }
+
+      try
+      {
+        var type = typeof(TParameterType);
+        var value = @event.Get<TParameterType>();
+        EventQuery<T> eventQuery;
+        if (value != null && _valueDictionary.TryGetValue(value, out eventQuery))
+          eventQuery.Raise(@event);
+      }
+      finally
+      {
+        @event.ActiveRaiseDepth--;
+      }
     }
 
     public EventQuery<T> Where(in object value)
@@ -265,11 +300,25 @@ namespace Nopnag.EventBusLib // Updated namespace
 
     public override void Raise(T @event)
     {
-      var type = typeof(TParameterType);
-      var value = @event.GetGeneric<TParameterType>();
-      EventQuery<T> eventQuery;
-      if (value != null && _valueDictionary.TryGetValue(value, out eventQuery))
-        eventQuery.Raise(@event);
+      var isDepthZero = @event.ActiveRaiseDepth == 0;
+      @event.ActiveRaiseDepth++;
+      if (isDepthZero)
+      {
+        @event.RaiseUniqueId = EventBus.NextRaiseUniqueId();
+      }
+
+      try
+      {
+        var type = typeof(TParameterType);
+        var value = @event.GetGeneric<TParameterType>();
+        EventQuery<T> eventQuery;
+        if (value != null && _valueDictionary.TryGetValue(value, out eventQuery))
+          eventQuery.Raise(@event);
+      }
+      finally
+      {
+        @event.ActiveRaiseDepth--;
+      }
     }
 
     public EventQuery<T> Where(in object value)

--- a/Tests/EventBusInstanceTest.cs
+++ b/Tests/EventBusInstanceTest.cs
@@ -151,5 +151,74 @@ namespace Nopnag.EventBusLib.Tests
       staticListener.Unsubscribe();
       instanceListener.Unsubscribe();
     }
+
+    // -------------------- New tests for RaiseUniqueId and ActiveRaiseDepth (instance/static) --------------------
+
+    [Test]
+    public void LocalEventBus_AssignsRaiseUniqueId_PerRaise()
+    {
+      var localBus = new LocalEventBus();
+      long id1     = 0;
+      long id2     = 0;
+
+      var listener = localBus.On<TestEvent>().Listen(e =>
+      {
+        if (id1 == 0) id1 = e.RaiseUniqueId; else id2 = e.RaiseUniqueId;
+      });
+
+      var e = new TestEvent();
+      localBus.Raise(e);
+      localBus.Raise(e);
+
+      Assert.Greater(id1, 0);
+      Assert.Greater(id2, 0);
+      Assert.AreNotEqual(id1, id2);
+
+      listener.Unsubscribe();
+    }
+
+    [Test]
+    public void LocalEventBus_ChainedFilters_PreserveSameId()
+    {
+      var localBus = new LocalEventBus();
+      var src      = new object();
+      var tgt      = new object();
+
+      long idUnfiltered = 0;
+      long idFiltered   = 0;
+
+      var l1 = localBus.On<TestEvent>().Listen(e => { idUnfiltered = e.RaiseUniqueId; });
+      var l2 = localBus.On<TestEvent>().Where<Source>(src).Where<Target>(tgt).Listen(e => { idFiltered = e.RaiseUniqueId; });
+
+      var e = new TestEvent();
+      e.Set<Source>(src);
+      e.Set<Target>(tgt);
+      localBus.Raise(e);
+
+      Assert.Greater(idUnfiltered, 0);
+      Assert.AreEqual(idUnfiltered, idFiltered);
+
+      l1.Unsubscribe();
+      l2.Unsubscribe();
+    }
+
+    [Test]
+    public void StaticGenericVsStaticWrapper_BothAssignIds()
+    {
+      long idFromGeneric = 0;
+      long idFromWrapper = 0;
+
+      var l = EventBus<TestEvent>.Listen(e => { idFromGeneric = e.RaiseUniqueId; });
+      var e = new TestEvent();
+      EventBus<TestEvent>.Raise(e);
+      Assert.Greater(idFromGeneric, 0);
+      l.Unsubscribe();
+
+      var l2 = EventBus<TestEvent>.Listen(e => { idFromWrapper = e.RaiseUniqueId; });
+      var e2 = new TestEvent();
+      EventBus.Raise(e2);
+      Assert.Greater(idFromWrapper, 0);
+      l2.Unsubscribe();
+    }
   }
 }

--- a/Tests/EventBusTest.cs
+++ b/Tests/EventBusTest.cs
@@ -579,5 +579,136 @@ namespace Nopnag.EventBusLib.Tests
       // Ensure l6 is still unsubscribed (implicitly)
       // No need to explicitly check l6 as it calls Assert.Fail() if ever triggered.
     }
+
+    // -------------------- New tests for RaiseUniqueId and dispatch depth --------------------
+
+    public class IdTestEvent : BusEvent
+    {
+    }
+
+    public class NestedEvent : BusEvent
+    {
+    }
+
+    public class MetaInfo // class-based generic parameter (does not implement IParameter)
+    {
+      public string Name;
+    }
+
+    [Test]
+    public void RaiseUniqueId_AssignedOnRaise_NotOnCreation()
+    {
+      var e = new IdTestEvent();
+      Assert.AreEqual(0, e.RaiseUniqueId, "ID should be 0 before first raise");
+
+      long idObservedInListener = 0;
+      var listener = EventBus<IdTestEvent>.Listen(ev => { idObservedInListener = ev.RaiseUniqueId; });
+
+      EventBus<IdTestEvent>.Raise(e);
+
+      Assert.Greater(e.RaiseUniqueId, 0, "ID should be assigned during raise");
+      Assert.AreEqual(e.RaiseUniqueId, idObservedInListener, "Listener should observe same ID");
+
+      listener.Unsubscribe();
+    }
+
+    [Test]
+    public void RaiseUniqueId_DiffersAcrossSeparateRaises_EvenWithSameInstance()
+    {
+      var e = new IdTestEvent();
+      long firstId  = 0;
+      long secondId = 0;
+
+      var listener = EventBus<IdTestEvent>.Listen(ev =>
+      {
+        if (firstId == 0) firstId = ev.RaiseUniqueId; else secondId = ev.RaiseUniqueId;
+      });
+
+      EventBus<IdTestEvent>.Raise(e);
+      EventBus<IdTestEvent>.Raise(e);
+
+      Assert.Greater(firstId, 0);
+      Assert.Greater(secondId, 0);
+      Assert.AreNotEqual(firstId, secondId, "Each top-level raise must have a new ID");
+
+      listener.Unsubscribe();
+    }
+
+    [Test]
+    public void RaiseUniqueId_StaticWrapper_AssignsId()
+    {
+      var e = new IdTestEvent();
+      long idInListener = 0;
+
+      var listener = EventBus<IdTestEvent>.Listen(ev => { idInListener = ev.RaiseUniqueId; });
+
+      EventBus.Raise(e);
+
+      Assert.Greater(e.RaiseUniqueId, 0);
+      Assert.AreEqual(e.RaiseUniqueId, idInListener);
+
+      listener.Unsubscribe();
+    }
+
+    [Test]
+    public void RaiseUniqueId_StableAcrossQueryChain_ParameterFiltering()
+    {
+      var e = new IdTestEvent();
+      e.Set<Amount>(15);
+      long idUnfiltered = 0;
+      long idFiltered   = 0;
+
+      var l1 = EventBus<IdTestEvent>.Listen(ev => { idUnfiltered = ev.RaiseUniqueId; });
+      var l2 = EventBus<IdTestEvent>.Where<Amount>(15).Listen(ev => { idFiltered = ev.RaiseUniqueId; });
+
+      EventBus<IdTestEvent>.Raise(e);
+
+      Assert.Greater(idUnfiltered, 0);
+      Assert.AreEqual(idUnfiltered, idFiltered, "Chain propagation must preserve the same ID");
+
+      l1.Unsubscribe();
+      l2.Unsubscribe();
+    }
+
+    [Test]
+    public void RaiseUniqueId_StableAcrossQueryChain_GenericParameterFiltering()
+    {
+      var meta = new MetaInfo { Name = "meta" };
+      var e    = new IdTestEvent();
+      e.Set(meta);
+
+      long idUnfiltered = 0;
+      long idFiltered   = 0;
+
+      var l1 = EventBus<IdTestEvent>.Listen(ev => { idUnfiltered = ev.RaiseUniqueId; });
+      var l2 = EventBus<IdTestEvent>.Where(meta).Listen(ev => { idFiltered = ev.RaiseUniqueId; });
+
+      EventBus<IdTestEvent>.Raise(e);
+
+      Assert.Greater(idUnfiltered, 0);
+      Assert.AreEqual(idUnfiltered, idFiltered);
+
+      l1.Unsubscribe();
+      l2.Unsubscribe();
+    }
+
+    [Test]
+    public void NestedDifferentEvent_RaisesHaveDifferentIds()
+    {
+      long rootId   = 0;
+      long nestedId = 0;
+
+      var rootListener   = EventBus<IdTestEvent>.Listen(ev => { rootId = ev.RaiseUniqueId; EventBus<NestedEvent>.Raise(new NestedEvent()); });
+      var nestedListener = EventBus<NestedEvent>.Listen(ev => { nestedId = ev.RaiseUniqueId; });
+
+      EventBus<IdTestEvent>.Raise(new IdTestEvent());
+
+      Assert.Greater(rootId, 0);
+      Assert.Greater(nestedId, 0);
+      Assert.AreNotEqual(rootId, nestedId, "Different events in nested raises must get different IDs");
+
+      rootListener.Unsubscribe();
+      nestedListener.Unsubscribe();
+    }
   }
 }


### PR DESCRIPTION
- Add RaiseUniqueId property to BusEvent (public getter, internal setter)
- Add ActiveRaiseDepth internal tracking for nested raise detection
- Implement thread-safe ID generator using Interlocked.Increment
- Assign unique ID once per top-level raise, preserved across chain propagation
- Update all Raise methods (EventQuery, ParameterQuery, GenericParameterQuery)
- Add comprehensive tests covering all raise paths and scenarios
- Tests verify ID assignment, uniqueness, and stability across filtered chains